### PR TITLE
Fix error message in dispatchCommand

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -756,7 +756,7 @@ export class Client extends EventEmitter {
       throw new ClientError(
         ClientErrorCode.ErrPayloadTooBig,
         `${serializer ? 'Serialized payload' : 'Payload'} is too big,` +
-        ` maximum size is ${maxPayloadSize} bytes, got ${payloadBuffer.length}`
+          ` maximum size is ${maxPayloadSize} bytes, got ${payloadBuffer.length}`
       );
     }
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -756,7 +756,7 @@ export class Client extends EventEmitter {
       throw new ClientError(
         ClientErrorCode.ErrPayloadTooBig,
         `${serializer ? 'Serialized payload' : 'Payload'} is too big,` +
-          ` maximum size is ${maxPayloadSize} bytes, got ${payloadBuffer.length}`
+        ` maximum size is ${maxPayloadSize} bytes, got ${payloadBuffer.length}`
       );
     }
 
@@ -848,7 +848,7 @@ export class Client extends EventEmitter {
       if (conn.getState() !== 'open') {
         throw new ClientError(
           ClientErrorCode.ErrConnectionNotOpened,
-          `Unable to dispatch command on not opened connection, connection state is '${conn.getState}'`
+          `Unable to dispatch command on not opened connection, connection state is '${conn.getState()}'`
         );
       }
 


### PR DESCRIPTION
### What is the current behavior, and the steps to reproduce the issue?

Error message reads: 

```
ClientError: Unable to dispatch command on not opened connection, connection state is 'function () {
        return this._state;
    }'
```

### What is the expected behavior?

Error message should read:

```
ClientError: Unable to dispatch command on not opened connection, connection state is 'opening'
```

### How does this PR fix the problem?

Output the return value of the getState() function, instead of the getState() function itself.

